### PR TITLE
refactor: removed anchorCallback prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ The \<ods-hyperlink> element should be used in situations where users may:
 
 | Attribute | value type | Description |
 |----|----|----|
-| anchorCallback | function | Function callback hook |
 | cta | boolean | Specifies the style of the hyperlink to appear as a CTA button |
 | download | boolean | Specifies that the target will be downloaded when a user clicks on the hyperlink |
 | darktheme | boolean | Specifies dark theme use of hyperlink |

--- a/demo/index.html
+++ b/demo/index.html
@@ -190,6 +190,40 @@
         </template>
       </demo-snippet>
 
+      <demo-snippet>
+        <template>
+          <div role="tablist" class="ods-tablist" id="working-tabs">
+              <ods-hyperlink tabisactive="true" role="tab">Tab One</ods-hyperlink>
+              <ods-hyperlink role="tab">Tab Two</ods-hyperlink>
+              <ods-hyperlink role="tab">Tab Three</ods-hyperlink>
+          </div>
+          <script>
+            const tabs = [...document.querySelectorAll('#working-tabs ods-hyperlink')];
+            const removeActive = () => {
+              tabs.forEach(tab => {
+                tab.setAttribute('tabisactive', false);
+              });
+            };
+
+            tabs.forEach(tab => {
+              tab.addEventListener('click', () => {
+                removeActive();
+                tab.setAttribute('tabisactive', true);
+              });
+            });
+            </script>
+        </template>
+      </demo-snippet>
+
+    <demo-snippet>
+      <template>
+          <ods-hyperlink id="cancel" role="button">Cancel</ods-hyperlink>
+          <script>
+            document.querySelector('#cancel').addEventListener('click', () => alert('cancel clicked'));
+          </script>
+      </template>
+    </demo-snippet>
+
       <h2>Element &#60;ods-hyperlink&#62;</h2>
 
       <pre><code>class OdsHyperlink extends LitElement</code></pre>

--- a/src/ods-hyperlink.js
+++ b/src/ods-hyperlink.js
@@ -52,13 +52,8 @@ class OdsHyperlink extends LitElement {
       role:             { type: String },
       tabisactive:      { type: String },
       target:           { type: String },
-      type:             { type: String },
-      anchorCallback:   { type: Function }
+      type:             { type: String }
     };
-  }
-
-  anchorCallback() {
-    alert('Alert: Event not bound to anchor')
   }
 
   getContext(inline) {
@@ -155,7 +150,6 @@ class OdsHyperlink extends LitElement {
         class="${this.getAnchortype(this.role, this.href)} ${this.getContext(this.inline)} ${this.getTheme(this.darktheme)} ${this.getCta(this.cta)} ${this.getTabState(this.tabisactive)}"
         href="${ifDefined(this.href ? this.href : undefined)}"
         target="${ifDefined(this.target ? this.target : undefined)}"
-        @click=${ifDefined(this.role === 'button' || this.role === 'tab' ? this.anchorCallback : undefined)}"
         tabindex="${ifDefined(this.role === 'button' || this.role === 'tab' ? '0' : undefined)}"
       ><slot></slot>${this.targetIcon(this.target)}</a>
     `;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Removed `anchorCallback` prop in favor of more standard event listener model. 

## Summary:

Removed the `anchorCallback` prop as it is in unnecessary. Also removed logic around preventing click events from only happening if link is of `role` type `button` or `tab`. Normal html `a` tags are capable of having click events associated with them and disabling that functionality for user protection while nice (and hopefully no one will add a click event to an `a` tag), only confuses implementation. 

## Type of change:

- removed `anchorCallback`
- added `click` event listener examples to demo page
- updated README

- [ ] New capability 
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate) 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
