### PR TITLE
fix: element only defines itself if the element is not already defined

### DIFF
--- a/src/ods-hyperlink.js
+++ b/src/ods-hyperlink.js
@@ -159,4 +159,6 @@ class OdsHyperlink extends LitElement {
 }
 
 // define the name of the custom component
-customElements.define("ods-hyperlink", OdsHyperlink);
+if(!customElements.get("ods-hyperlink")) {
+  customElements.define("ods-hyperlink", OdsHyperlink);
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request
## Summary:

Added a check around the element defining operation. This prevents the element from attempting to define itself when it's already defined. This will prevent console errors in the event of multiple pieces of code on the same page depending on the hyperlink element

## Type of change:

Please delete options that are not relevant.

- [ ] New capability 
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate) 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
